### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/ByHelpers/attributes.py
+++ b/ByHelpers/attributes.py
@@ -2,8 +2,8 @@
 
 import unicodedata
 import string
-from fuzzywuzzy import fuzz
-from fuzzywuzzy import process
+from rapidfuzz import fuzz
+from rapidfuzz import process
 import re
 
 ATTRIBUTES = [
@@ -693,7 +693,7 @@ class Attributes:
                 text = ''.join(x for x in unicodedata.normalize('NFKD', value) if x in string.ascii_letters or x in [" ", '"', "'", '.', ',']).lower()
                 text = text.strip()
                 text = re.sub(r'\s+', ' ', text)
-                result = process.extractOne(text, choices, scorer=fuzz.UWRatio, score_cutoff=min_score)
+                result = process.extractOne(text, choices, scorer=fuzz.WRatio, score_cutoff=min_score)
                 if result and result[1] > min_score:
                     return True
                 else:

--- a/ByHelpers/nutrition_facts.py
+++ b/ByHelpers/nutrition_facts.py
@@ -2,8 +2,8 @@
 
 import unicodedata
 import string
-from fuzzywuzzy import fuzz
-from fuzzywuzzy import process
+from rapidfuzz import fuzz
+from rapidfuzz import process
 import re
 
 
@@ -609,7 +609,7 @@ class Nutriments:
         for unit in WEIGHT_UNITS:
             choices = unit.get("match")
             if trustier_text is not False:
-                result = process.extractOne(text, choices, scorer=fuzz.UWRatio, score_cutoff=min_score)
+                result = process.extractOne(text, choices, scorer=fuzz.WRatio, score_cutoff=min_score)
                 if result is not None:
                     aux = unit.get('name_es') if self.langage == 'es' else unit.get('name')
                     return aux, result[0]

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     keywords=['ByPrice'],
     install_requires=[
         'pika==0.11.0',
-        'fuzzywuzzy==0.16.0',
+        'rapidfuzz==0.3.0',
         'fluent-logger==0.9.4'
     ],
     classifiers=(


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy